### PR TITLE
v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is an Android application and Home Assistant integration to compliment the 
 
 ## How is this different from existing solutions?
 
-Other solutions are a combination of applications for voice and display and often have quite an involved setup. VACA is a 1-stop shop of voice and browser support providing a simplified setup with just a signle Android application install. Built specifically for View Assist also means that it provides the features and capabilities needed to support this project, without having to piece other solutions together.
+Other solutions are a combination of applications for voice and display and often have quite an involved setup. VACA is a 1-stop shop of voice and browser support providing a simplified setup with just a single Android application install. Built specifically for View Assist also means that it provides the features and capabilities needed to support this project, without having to piece other solutions together.
 
 ## Will it work for me?
 
@@ -45,10 +45,45 @@ There are 2 components to this solution, a HA custom integration and an Android 
 
 ### Custom Integration
 
-As is common with new custom instegrations, it can take a little while to be fully available via HACs. However, you can add this as a custom respository by the following link to then provide the normal HACs install and update experience.
+As is common with new custom integrations, it can take a little while to be fully available via HACs. However, you can add this as a custom respository by the following link to then provide the normal HACs install and update experience.
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=msp1974&repository=ViewAssist_Companion_App&category=Integration)
 
 ### Android Application
 
 The app is not currently available in the Play store and will need to be downloaded from the apk folder in this repository and installed on your device.
+
+# FAQs
+
+### My device detects the wake word ok but then doesn't hear what I am saying
+
+This is caused by the mic gain setting either being too low or too high. Too low and it will struggle to hear you, too high and it will clip the audio and make your voice unintelligable.
+
+- On a Lenovo TSV, start at 1 and don't go any more than 5
+- On a Lenovo LSD 8 & 10, try a setting of around 60 and adjust between 40 and 80 to get the best result
+- On other devices, always start at 1 and adjust in increments of 1 if it hears you but needs to be more sensitive or in increments of 10 if it doesn't hear you at all when set to 1.
+
+---
+
+### I dont understand how to turn the screen off on my device
+
+There is some variation here with how devices will turn on/off their screens.
+
+- Lenovo TSV - use the keep screen on switch and set the screen timeout on your device low. When keep screen on if set to off, it will sleep on this screne timeout. Turin keep screen on back to on, will wake up the screen.
+- Lenovo LSD - use the brightness slider and set to 0 to turn screen off
+- Lenovo SC2 - set auto brightness to off and then set brightness to 0.
+- Other devices - try any of the above solutions. In the main, the more modern the device the more likley the TSV solution is the right answer.
+
+---
+
+### Can I use a custom wake word
+
+This is a future ambition but for now it is limited to those listed and built into the app
+
+---
+
+### Can I use a custom wake word sound
+
+See above answer!
+
+---

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ This is caused by the mic gain setting either being too low or too high. Too low
 
 ---
 
+### My device doesn't pick up the wake word or picks up too many false positives
+
+Try adjusting the wake word threshold. It is default set to 80 but play around with it until it works the best. The lower the setting the more it will detect but becomes more suseptable to fale positives. The higher it is, the more likley background noise will stop it detecting. Default is 80 as that seems to be the best compromise in most tested situations.
+
+---
+
 ### I dont understand how to turn the screen off on my device
 
 There is some variation here with how devices will turn on/off their screens.

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -101,7 +101,6 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
 
         # Init custom settings
         self.device.custom_settings = {}
-        self.device.custom_settings["ha_port"] = hass.config.api.port
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
@@ -116,6 +115,12 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
     async def on_after_send_event_callback(self, event: Event) -> None:
         """Allow injection of events after event sent."""
         if RunSatellite().is_type(event.type):
+            # Update url and port
+            self.device.custom_settings["ha_port"] = self.hass.config.api.port
+            self.device.custom_settings["ha_url"] = (
+                self.hass.config.internal_url if self.hass.config.internal_url else ""
+            )
+            # Send config event
             await self._client.write_event(
                 CustomSettings(self.device.custom_settings).event()
             )

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -176,17 +176,22 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                 if self.device.tts_listener is not None:
                     self.device.tts_listener(event.data["tts_input"])
         elif event.type == assist_pipeline.PipelineEventType.INTENT_END:
-            # Intent processing complete - to be converted to intent sensor
+            # Intent processing complete - update intent sensor
             if event.data:
                 _LOGGER.debug(
                     "Intent processing complete: %s",
                     event.data,
                 )
-                event_data = {
-                    "result": event.data.get("intent_output"),
-                    "device_id": self.device.device_id,
-                }
-                # self.hass.bus.async_fire(INTENT_EVENT, event_data)
+                if (
+                    event.data.get("intent_output", {})
+                    .get("response", {})
+                    .get("speech")
+                ):
+                    async_dispatcher_send(
+                        self.hass,
+                        f"{DOMAIN}_{self.device.device_id}_intent_output",
+                        event.data,
+                    )
 
         super().on_pipeline_event(event)
 

--- a/custom_components/vaca/manifest.json
+++ b/custom_components/vaca/manifest.json
@@ -15,6 +15,6 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "requirements": ["wyoming>=1.7.1"],
-  "version": "0.3.0",
+  "version": "0.3.1",
   "zeroconf": ["_vaca._tcp.local."]
 }

--- a/custom_components/vaca/manifest.json
+++ b/custom_components/vaca/manifest.json
@@ -15,6 +15,6 @@
   "integration_type": "service",
   "iot_class": "local_push",
   "requirements": ["wyoming>=1.7.1"],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "zeroconf": ["_vaca._tcp.local."]
 }

--- a/custom_components/vaca/number.py
+++ b/custom_components/vaca/number.py
@@ -56,7 +56,7 @@ class WyomingSatelliteMicGainNumber(VASatelliteEntity, RestoreNumber):
     _attr_should_poll = False
     _attr_native_min_value = 1
     _attr_native_max_value = _MAX_MIC_GAIN
-    _attr_native_value = 20
+    _attr_native_value = 1
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to Home Assistant."""

--- a/custom_components/vaca/switch.py
+++ b/custom_components/vaca/switch.py
@@ -35,6 +35,7 @@ async def async_setup_entry(
             WyomingSatelliteSwipeToRefreshSwitch(item.device),
             WyomingSatelliteScreenAutoBrightnessSwitch(item.device),
             WyomingSatelliteScreenAlwaysOnSwitch(item.device),
+            WyomingSatelliteDarkModeSwitch(item.device),
         ]
     )
 
@@ -170,6 +171,43 @@ class WyomingSatelliteScreenAlwaysOnSwitch(
 
         # Default to on
         self._attr_is_on = (state is None) or (state.state == STATE_ON)
+        await self.do_switch(self._attr_is_on)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on."""
+        await self.do_switch(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off."""
+        await self.do_switch(False)
+
+    async def do_switch(self, value: bool) -> None:
+        """Perform the switch action."""
+        self._attr_is_on = value
+        self.async_write_ha_state()
+        self._device.set_custom_setting(self.entity_description.key, self._attr_is_on)
+
+
+class WyomingSatelliteDarkModeSwitch(
+    VASatelliteEntity, restore_state.RestoreEntity, SwitchEntity
+):
+    """Entity to control screen always on."""
+
+    entity_description = SwitchEntityDescription(
+        key="dark_mode",
+        translation_key="dark_mode",
+        icon="mdi:compare",
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity about to be added to hass."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+
+        # Default to on
+        self._attr_is_on = (state is not None) and (state.state == STATE_ON)
         await self.do_switch(self._attr_is_on)
 
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/custom_components/vaca/translations/en.json
+++ b/custom_components/vaca/translations/en.json
@@ -104,6 +104,9 @@
             "tts": {
                 "name": "TTS"
             },
+            "intent": {
+                "name": "Intent"
+            },
             "light_level": {
                 "name": "Light level"
             },

--- a/custom_components/vaca/translations/en.json
+++ b/custom_components/vaca/translations/en.json
@@ -131,8 +131,10 @@
             },
             "do_not_disturb": {
                 "name": "Do not disturb"
+            },
+            "dark_mode": {
+                "name": "Dark mode"
             }
-
         }
     }
 }


### PR DESCRIPTION
## New features & improvements
- Added an intent sensor for use with View Assist intent functionality (may require an update to VA version currently in dev branch) - #3 
- Added dark mode switch to make HA switch between light and dark mode of themes (theme must support this) - #2
- Default mic gain setting for new installs is set to 1 - #8 

## Bug fixes
- Webview will use the HA url from the internal URL setting if available to support SSL or proxied installs - #6
- Fixed wake word detection engine errors if using a locale that defines a comma as a decimal seperator - #5
- Fix issue whereby the wake word can stop detecting if too many disconnections and reconnections to HA happen.
