### PR TITLE
Send intent-output event to satellite client

### DIFF
--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -260,6 +260,19 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                     event.type,
                     event.data,
                 )
+                if self._client is not None:
+                    # Update client with intent output structure
+                    self.config_entry.async_create_background_task(
+                        self.hass,
+                        self._client.write_event(
+                            CustomEvent(
+                                ACTION_EVENT_TYPE,
+                                {"action": "intent-output", "data": event.data},
+                            ).event()
+                        ),
+                        "send intent output event",
+                    )
+
                 if (
                     event.data.get("intent_output", {})
                     .get("response", {})


### PR DESCRIPTION
This PR updates the `assist_satellite` component to explicitly forward `intent-output` events to the connected satellite client. This is a requirement for the companion app to correctly handle conversation continuation.

## Rationale

To support the refactored `ClientHandler` and its "Conversation Continuation" feature (see [Companion App PR #22](https://github.com/msp1974/ViewAssistCompanionApp/pull/22)), the satellite client needs to receive the raw `intent-output` event from the Assist pipeline. 

This event contains the `continue_conversation` flag and other metadata that the client uses to determine if it should automatically surface the listening UI for a follow-up response. Without this change, the satellite remains unaware of the "continued conversation" state requested by Home Assistant.

## Major Changes

### 1. Event Forwarding in `assist_satellite.py`

- Modified `ViewAssistSatelliteEntity` to intercept `intent-output` events from the pipeline.
- implemented a mechanism to wrap these events into a `CustomEvent` and write them to the client through `self._client.write_event()`.
- Uses `async_create_background_task` to ensure the event is sent immediately without blocking the event handler loop.