### PR TITLE
Add screensaver coordination and local fallback handling

### DIFF
--- a/custom_components/vaca/__init__.py
+++ b/custom_components/vaca/__init__.py
@@ -36,6 +36,7 @@ SATELLITE_PLATFORMS = [
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.SENSOR,
+    Platform.TEXT,
 ]
 
 __all__ = [

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -43,6 +43,7 @@ from .custom import (
     PipelineEnded,
     getIntegrationVersion,
     getVADashboardPath,
+    getVASensorEntityId,
 )
 from .devices import VASatelliteDevice
 from .entity import VASatelliteEntity
@@ -225,6 +226,19 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
         if isinstance(current_path, str) and current_path.strip():
             normalized_current_path = self._normalize_path(current_path, "/")
             self._last_current_path = normalized_current_path
+            if va_sensor_entity_id := getVASensorEntityId(
+                self.hass, self.device.satellite_id
+            ):
+                self.hass.async_create_task(
+                    self.hass.services.async_call(
+                        "view_assist",
+                        "set_state",
+                        {
+                            "entity_id": va_sensor_entity_id,
+                            "current_path": normalized_current_path,
+                        },
+                    )
+                )
             screensaver_path = self._normalize_path(
                 self.device.custom_settings.get("ha_screensaver_dashboard")
                 if self.device.custom_settings

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -299,6 +299,19 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
             "/view-assist/clock",
         )
         current_path = self._last_current_path
+        if not current_path:
+            if seeded_current_path := self._get_seed_current_path():
+                current_path = seeded_current_path
+                self._last_current_path = seeded_current_path
+                async_dispatcher_send(
+                    self.hass,
+                    f"{DOMAIN}_{self.device.device_id}_status_update",
+                    {"sensors": {"current_path": seeded_current_path}},
+                )
+                _LOGGER.debug(
+                    "Recovered VACA current_path during ui_idle handling: %s",
+                    seeded_current_path,
+                )
         on_home_path = bool(current_path) and current_path.startswith(home_path)
         on_screensaver_path = bool(current_path) and current_path.startswith(
             screensaver_path

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -114,6 +114,10 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
         # stream tts var to allow interupt and cancel remaining response
         self.stream_tts = False
         self._last_ui_idle: bool | None = None
+        self._last_current_path: str | None = None
+        self._screensaver_active = False
+        self._pending_non_screensaver_path: str | None = None
+        self._pending_non_screensaver_until = 0.0
 
     async def on_restart(self) -> None:
         """Block until pipeline loop will be restarted."""
@@ -208,10 +212,44 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
     def _process_ui_idle_status(self, event_data: dict[str, Any]) -> None:
         """Map ui_idle status transitions to navigation actions."""
         sensors = event_data.get("sensors")
-        if not isinstance(sensors, dict) or "ui_idle" not in sensors:
+        if not isinstance(sensors, dict):
+            return
+
+        ha_navigate_screensaver = bool(
+            self.device.custom_settings.get("ha_navigate_screensaver")
+            if self.device.custom_settings
+            else False
+        )
+
+        current_path = sensors.get("current_path")
+        if isinstance(current_path, str) and current_path.strip():
+            normalized_current_path = self._normalize_path(current_path, "/")
+            self._last_current_path = normalized_current_path
+            screensaver_path = self._normalize_path(
+                self.device.custom_settings.get("ha_screensaver_dashboard")
+                if self.device.custom_settings
+                else None,
+                "/dashboard-screensaver",
+            )
+            self._screensaver_active = normalized_current_path.startswith(
+                screensaver_path
+            )
+            if normalized_current_path == self._pending_non_screensaver_path:
+                self._pending_non_screensaver_path = None
+                self._pending_non_screensaver_until = 0.0
+
+        if "ui_idle" not in sensors:
             return
 
         ui_idle = bool(sensors["ui_idle"])
+        if not ha_navigate_screensaver:
+            self._last_ui_idle = ui_idle
+            _LOGGER.debug(
+                "Ignoring ui_idle=%s because ha_navigate_screensaver is disabled",
+                ui_idle,
+            )
+            return
+
         previous = self._last_ui_idle
         self._last_ui_idle = ui_idle
 
@@ -231,26 +269,57 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
             else None,
             "/view-assist/clock",
         )
+        current_path = self._last_current_path
+        on_home_path = bool(current_path) and current_path.startswith(home_path)
+        on_screensaver_path = bool(current_path) and current_path.startswith(
+            screensaver_path
+        )
 
         if ui_idle:
-            _LOGGER.debug(
-                "ui_idle transition false->true, navigating to screensaver: %s",
-                screensaver_path,
-            )
-            self._send_custom_action(
-                "navigate",
-                {"path": screensaver_path, "revert_timeout": 0},
-            )
+            if on_home_path:
+                _LOGGER.debug(
+                    "ui_idle transition false->true on home path %s, navigating to screensaver: %s",
+                    home_path,
+                    screensaver_path,
+                )
+                self._screensaver_active = True
+                self._send_custom_action(
+                    "navigate",
+                    {"path": screensaver_path, "revert_timeout": 0},
+                )
+            else:
+                _LOGGER.debug(
+                    "ui_idle transition false->true ignored because current_path=%s is not home_path=%s",
+                    current_path,
+                    home_path,
+                )
         elif previous is True:
-            _LOGGER.debug(
-                "ui_idle transition true->false, waking and navigating home: %s",
-                home_path,
-            )
-            self._send_custom_action("screen-wake", None)
-            self._send_custom_action(
-                "navigate",
-                {"path": home_path, "revert_timeout": 0},
-            )
+            if (
+                self._pending_non_screensaver_path
+                and time.monotonic() < self._pending_non_screensaver_until
+            ):
+                _LOGGER.debug(
+                    "ui_idle transition true->false ignored due to pending navigation to %s",
+                    self._pending_non_screensaver_path,
+                )
+                return
+            if self._screensaver_active or on_screensaver_path:
+                _LOGGER.debug(
+                    "ui_idle transition true->false from screensaver, waking and navigating home: %s",
+                    home_path,
+                )
+                self._screensaver_active = False
+                self._send_custom_action("screen-wake", None)
+                self._send_custom_action(
+                    "navigate",
+                    {"path": home_path, "revert_timeout": 0},
+                )
+            else:
+                _LOGGER.debug(
+                    "ui_idle transition true->false ignored because current_path=%s is not screensaver_path=%s",
+                    current_path,
+                    screensaver_path,
+                )
 
     @staticmethod
     def _normalize_path(path: Any, default: str) -> str:
@@ -293,6 +362,10 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
         """Connect to satellite over TCP.  Uses custom TCP client to allow callbacks on send."""
         await self._disconnect()
         self._last_ui_idle = None
+        self._last_current_path = None
+        self._screensaver_active = False
+        self._pending_non_screensaver_path = None
+        self._pending_non_screensaver_until = 0.0
 
         _LOGGER.debug(
             "Connecting VACA to satellite at %s:%s",
@@ -525,10 +598,24 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                 "custom settings event",
             )
 
-    def _send_custom_action(
-        self, command: str, payload: str | float | None = None
-    ) -> None:
+    def _send_custom_action(self, command: str, payload: Any = None) -> None:
         """Send a media player command to the satellite."""
+        if command == "navigate" and isinstance(payload, dict):
+            path = payload.get("path")
+            if isinstance(path, str) and path.strip():
+                normalized_path = self._normalize_path(path, "/")
+                screensaver_path = self._normalize_path(
+                    self.device.custom_settings.get("ha_screensaver_dashboard")
+                    if self.device.custom_settings
+                    else None,
+                    "/dashboard-screensaver",
+                )
+                if not normalized_path.startswith(screensaver_path):
+                    self._pending_non_screensaver_path = normalized_path
+                    self._pending_non_screensaver_until = time.monotonic() + 5.0
+                else:
+                    self._pending_non_screensaver_path = None
+                    self._pending_non_screensaver_until = 0.0
         _LOGGER.debug(
             "Sending custom action to satellite: command=%s payload=%s",
             command,

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -161,16 +161,7 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                     if self.hass.config.internal_url
                     else ""
                 )
-                screensaver_path = (
-                    self.device.custom_settings.get("screensaver_dashboard")
-                    if self.device.custom_settings
-                    else None
-                )
-                if not isinstance(screensaver_path, str) or not screensaver_path.strip():
-                    screensaver_path = "/dashboard-screensaver"
-                elif not screensaver_path.startswith("/"):
-                    screensaver_path = f"/{screensaver_path}"
-                self.device.custom_settings["ha_screensaver_dashboard"] = screensaver_path
+                self._apply_screensaver_settings()
                 home = getVADashboardPath(self.hass, self.device.satellite_id)
                 self.device.custom_settings["ha_dashboard"] = home.removeprefix("/")
                 # Send config event
@@ -269,9 +260,39 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
         path = path.strip()
         return path if path.startswith("/") else f"/{path}"
 
+    def _apply_screensaver_settings(self) -> tuple[str, bool]:
+        """Update derived screensaver settings."""
+        screensaver_path = (
+            self.device.custom_settings.get("screensaver_dashboard")
+            if self.device.custom_settings
+            else None
+        )
+        if isinstance(screensaver_path, str):
+            screensaver_path = screensaver_path.strip()
+
+        if isinstance(screensaver_path, str) and screensaver_path:
+            if not screensaver_path.startswith("/"):
+                screensaver_path = f"/{screensaver_path}"
+        else:
+            screensaver_path = ""
+
+        ha_navigate_screensaver = bool(
+            self.device.custom_settings.get("screen_saver")
+            if self.device.custom_settings
+            else False
+        ) and bool(screensaver_path)
+
+        assert self.device.custom_settings is not None
+        self.device.custom_settings["ha_screensaver_dashboard"] = screensaver_path
+        self.device.custom_settings["ha_navigate_screensaver"] = (
+            ha_navigate_screensaver
+        )
+        return screensaver_path, ha_navigate_screensaver
+
     async def _connect(self) -> None:
         """Connect to satellite over TCP.  Uses custom TCP client to allow callbacks on send."""
         await self._disconnect()
+        self._last_ui_idle = None
 
         _LOGGER.debug(
             "Connecting VACA to satellite at %s:%s",
@@ -480,15 +501,24 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
     ) -> None:
         """Run when device screen settings change."""
         if self._client is not None and self._client.can_write_event():
+            payload_settings = (
+                dict(self.device.custom_settings)
+                if setting is None
+                else {setting: value}
+            )
+            if setting in {"screen_saver", "screensaver_dashboard"}:
+                screensaver_path, ha_navigate_screensaver = (
+                    self._apply_screensaver_settings()
+                )
+                payload_settings["ha_screensaver_dashboard"] = screensaver_path
+                payload_settings["ha_navigate_screensaver"] = ha_navigate_screensaver
             self.config_entry.async_create_background_task(
                 self.hass,
                 self._client.write_event(
                     CustomEvent(
                         SETTINGS_EVENT_TYPE,
                         {
-                            SETTINGS_EVENT_TYPE: self.device.custom_settings
-                            if setting is None
-                            else {setting: value}
+                            SETTINGS_EVENT_TYPE: payload_settings
                         },
                     ).event()
                 ),

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -22,6 +22,7 @@ from homeassistant.components.assist_satellite import (
     AssistSatelliteEntityDescription,
     AssistSatelliteEntityFeature,
 )
+from homeassistant.components.assist_satellite.entity import AssistSatelliteState
 from homeassistant.components.wyoming import DomainDataItem, WyomingService
 
 # pylint: disable-next=hass-component-root-import
@@ -122,6 +123,8 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
 
     async def on_restart(self) -> None:
         """Block until pipeline loop will be restarted."""
+        self._attr_state = AssistSatelliteState.IDLE
+        self.async_write_ha_state()
         _LOGGER.warning(
             "Satellite %s has been disconnected. Reconnecting in %s second(s)",
             self.entity_id.replace("assist_satellite.", ""),
@@ -251,6 +254,18 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
             if normalized_current_path == self._pending_non_screensaver_path:
                 self._pending_non_screensaver_path = None
                 self._pending_non_screensaver_until = 0.0
+        elif not self._last_current_path:
+            if seeded_current_path := self._get_seed_current_path():
+                self._last_current_path = seeded_current_path
+                async_dispatcher_send(
+                    self.hass,
+                    f"{DOMAIN}_{self.device.device_id}_status_update",
+                    {"sensors": {"current_path": seeded_current_path}},
+                )
+                _LOGGER.debug(
+                    "Seeded VACA current_path from linked View Assist sensor: %s",
+                    seeded_current_path,
+                )
 
         if "ui_idle" not in sensors:
             return
@@ -335,6 +350,23 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                     screensaver_path,
                 )
 
+    def _get_seed_current_path(self) -> str | None:
+        """Recover current_path from the linked View Assist sensor when VACA lost it."""
+        va_sensor_entity_id = getVASensorEntityId(self.hass, self.device.satellite_id)
+        if not va_sensor_entity_id:
+            return None
+
+        if not (sensor_state := self.hass.states.get(va_sensor_entity_id)):
+            return None
+
+        candidate = sensor_state.attributes.get("current_path")
+        if not isinstance(candidate, str) or not candidate.strip():
+            candidate = sensor_state.attributes.get("home_screen")
+        if not isinstance(candidate, str) or not candidate.strip():
+            return None
+
+        return self._normalize_path(candidate, "/")
+
     @staticmethod
     def _normalize_path(path: Any, default: str) -> str:
         """Normalize path values from settings."""
@@ -375,6 +407,8 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
     async def _connect(self) -> None:
         """Connect to satellite over TCP.  Uses custom TCP client to allow callbacks on send."""
         await self._disconnect()
+        self._attr_state = AssistSatelliteState.IDLE
+        self.async_write_ha_state()
         self._last_ui_idle = None
         self._last_current_path = None
         self._screensaver_active = False

--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -113,6 +113,7 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
 
         # stream tts var to allow interupt and cancel remaining response
         self.stream_tts = False
+        self._last_ui_idle: bool | None = None
 
     async def on_restart(self) -> None:
         """Block until pipeline loop will be restarted."""
@@ -160,6 +161,16 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                     if self.hass.config.internal_url
                     else ""
                 )
+                screensaver_path = (
+                    self.device.custom_settings.get("screensaver_dashboard")
+                    if self.device.custom_settings
+                    else None
+                )
+                if not isinstance(screensaver_path, str) or not screensaver_path.strip():
+                    screensaver_path = "/dashboard-screensaver"
+                elif not screensaver_path.startswith("/"):
+                    screensaver_path = f"/{screensaver_path}"
+                self.device.custom_settings["ha_screensaver_dashboard"] = screensaver_path
                 home = getVADashboardPath(self.hass, self.device.satellite_id)
                 self.device.custom_settings["ha_dashboard"] = home.removeprefix("/")
                 # Send config event
@@ -190,6 +201,8 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                     evt.event_type,
                     evt.event_data,
                 )
+                if evt.event_type == STATUS_EVENT_TYPE and evt.event_data:
+                    self._process_ui_idle_status(evt.event_data)
 
             async_dispatcher_send(
                 self.hass,
@@ -199,6 +212,62 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
             return False, None
 
         return True, event
+
+    @callback
+    def _process_ui_idle_status(self, event_data: dict[str, Any]) -> None:
+        """Map ui_idle status transitions to navigation actions."""
+        sensors = event_data.get("sensors")
+        if not isinstance(sensors, dict) or "ui_idle" not in sensors:
+            return
+
+        ui_idle = bool(sensors["ui_idle"])
+        previous = self._last_ui_idle
+        self._last_ui_idle = ui_idle
+
+        # Only act on transitions.
+        if previous is ui_idle:
+            return
+
+        screensaver_path = self._normalize_path(
+            self.device.custom_settings.get("ha_screensaver_dashboard")
+            if self.device.custom_settings
+            else None,
+            "/dashboard-screensaver",
+        )
+        home_path = self._normalize_path(
+            self.device.custom_settings.get("ha_dashboard")
+            if self.device.custom_settings
+            else None,
+            "/view-assist/clock",
+        )
+
+        if ui_idle:
+            _LOGGER.debug(
+                "ui_idle transition false->true, navigating to screensaver: %s",
+                screensaver_path,
+            )
+            self._send_custom_action(
+                "navigate",
+                {"path": screensaver_path, "revert_timeout": 0},
+            )
+        elif previous is True:
+            _LOGGER.debug(
+                "ui_idle transition true->false, waking and navigating home: %s",
+                home_path,
+            )
+            self._send_custom_action("screen-wake", None)
+            self._send_custom_action(
+                "navigate",
+                {"path": home_path, "revert_timeout": 0},
+            )
+
+    @staticmethod
+    def _normalize_path(path: Any, default: str) -> str:
+        """Normalize path values from settings."""
+        if not isinstance(path, str) or not path.strip():
+            return default
+        path = path.strip()
+        return path if path.startswith("/") else f"/{path}"
 
     async def _connect(self) -> None:
         """Connect to satellite over TCP.  Uses custom TCP client to allow callbacks on send."""
@@ -430,6 +499,11 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
         self, command: str, payload: str | float | None = None
     ) -> None:
         """Send a media player command to the satellite."""
+        _LOGGER.debug(
+            "Sending custom action to satellite: command=%s payload=%s",
+            command,
+            payload,
+        )
         if self._client is not None and self._client.can_write_event():
             self.config_entry.async_create_background_task(
                 self.hass,

--- a/custom_components/vaca/binary_sensor.py
+++ b/custom_components/vaca/binary_sensor.py
@@ -43,6 +43,7 @@ async def async_setup_entry(
     entities = []
 
     entities.append(WyomingSatelliteScreenOnBinarySensor(device))
+    entities.append(WyomingSatelliteUiIdleBinarySensor(device))
 
     if capabilities := device.capabilities:
         if capabilities.get("has_battery"):
@@ -149,3 +150,13 @@ class WyomingSatelliteMotionDetectedSensor(_WyomingSatelliteDeviceBinarySensorBa
         await asyncio.sleep(20)
         self._attr_is_on = False
         self.schedule_update_ha_state()
+
+
+class WyomingSatelliteUiIdleBinarySensor(_WyomingSatelliteDeviceBinarySensorBase):
+    """Entity to represent UI idle status from the companion app."""
+
+    entity_description = BinarySensorEntityDescription(
+        key="ui_idle",
+        translation_key="ui_idle",
+        icon="mdi:power-sleep",
+    )

--- a/custom_components/vaca/button.py
+++ b/custom_components/vaca/button.py
@@ -34,6 +34,7 @@ async def async_setup_entry(
         [
             WyomingSatelliteWakeButton(device),
             WyomingSatelliteRefreshButton(device),
+            WyomingRestartUIButton(device),
             WyomingScreenSleepButton(device),
             WyomingScreenWakeButton(device),
         ]
@@ -62,6 +63,18 @@ class WyomingSatelliteRefreshButton(VASatelliteEntity, ButtonEntity):
     async def async_press(self) -> None:
         """Press the button."""
         self._device.send_custom_action(CustomActions.REFRESH)
+
+
+class WyomingRestartUIButton(VASatelliteEntity, ButtonEntity):
+    """Entity to perform a full UI restart/recovery."""
+
+    entity_description = ButtonEntityDescription(
+        key="restart_ui", translation_key="restart_ui", icon="mdi:restart"
+    )
+
+    async def async_press(self) -> None:
+        """Press the button."""
+        self._device.send_custom_action(CustomActions.RESTART_UI)
 
 
 class WyomingScreenSleepButton(VASatelliteEntity, ButtonEntity):

--- a/custom_components/vaca/custom.py
+++ b/custom_components/vaca/custom.py
@@ -100,30 +100,97 @@ async def getIntegrationVersion(hass: HomeAssistant) -> str | AwesomeVersion | N
 
 
 def getVADashboardPath(hass: HomeAssistant, uuid: str) -> str:
-    """Get the dashboard path."""
-    # Look for VA and a config entry that uses this uuid for display.  Then get the dashboard path
-    # from it or the master entry.  If not set, return empty string
+    """Get the effective View Assist home path for a VACA device."""
+
+    def get_sensor_entity_id(entry) -> str | None:
+        entity_reg = er.async_get(hass)
+        if integration_entities := er.async_entries_for_config_entry(
+            entity_reg, entry.entry_id
+        ):
+            for entity in integration_entities:
+                if entity.domain == "sensor":
+                    return entity.entity_id
+        return None
+
+    def resolve_home(entry) -> str:
+        runtime_data = getattr(entry, "runtime_data", None)
+        if runtime_data is not None:
+            try:
+                runtime_home = getattr(
+                    getattr(runtime_data, "runtime_config_overrides", None),
+                    "home",
+                    None,
+                )
+                if runtime_home:
+                    return runtime_home
+                dashboard_home = getattr(
+                    getattr(runtime_data, "dashboard", None),
+                    "home",
+                    None,
+                )
+                if dashboard_home:
+                    return dashboard_home
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Unable to read runtime View Assist home: %s", err)
+
+        if sensor_entity_id := get_sensor_entity_id(entry):
+            if sensor_state := hass.states.get(sensor_entity_id):
+                if home_screen := sensor_state.attributes.get("home_screen"):
+                    return home_screen
+
+        if home := entry.options.get("home"):
+            return home
+        return ""
+
+    # Look for the matching View Assist entry that uses this VACA device as mic_device.
+    if entries := hass.config_entries.async_entries(
+        "view_assist", include_disabled=False
+    ):
+        entity_reg = er.async_get(hass)
+        master_entry = next(
+            (entry for entry in entries if entry.data.get("type") == "master_config"),
+            None,
+        )
+        for entry in entries:
+            try:
+                if entry.data["type"] == "vaca":
+                    if mic_device := entry.data.get("mic_device", {}):
+                        if mic_device_entity := entity_reg.async_get(mic_device):
+                            entry_id = mic_device_entity.config_entry_id
+                            if entry_id == uuid:
+                                if home := resolve_home(entry):
+                                    return home
+                                if master_entry and (home := resolve_home(master_entry)):
+                                    return home
+                                return "/view-assist/clock"
+            except Exception as e:  # noqa: BLE001
+                _LOGGER.error("Error getting dashboard path: %s", e)
+                continue
+        if master_entry and (home := resolve_home(master_entry)):
+            return home
+    return "/view-assist/clock"
+
+
+def getVASensorEntityId(hass: HomeAssistant, uuid: str) -> str | None:
+    """Get the linked View Assist sensor entity id for a VACA device."""
     if entries := hass.config_entries.async_entries(
         "view_assist", include_disabled=False
     ):
         entity_reg = er.async_get(hass)
         for entry in entries:
             try:
-                if entry.data["type"] == "vaca":
-                    if mic_device := entry.data.get("mic_device", {}):
-                        # Get device id for this entity
-                        if mic_device_entity := entity_reg.async_get(mic_device):
-                            entry_id = mic_device_entity.config_entry_id
-                            if entry_id == uuid:
-                                if home := entry.options.get("home"):
-                                    return home
-                                # Look for master entry
-                                for master_entry in entries:
-                                    if master_entry.data["type"] == "master_config":
-                                        if home := master_entry.options.get("home"):
-                                            return home
-                                return "view-assist"
-            except Exception as e:  # noqa: BLE001
-                _LOGGER.error("Error getting dashboard path: %s", e)
+                if entry.data["type"] != "vaca":
+                    continue
+                if mic_device := entry.data.get("mic_device", {}):
+                    if mic_device_entity := entity_reg.async_get(mic_device):
+                        if mic_device_entity.config_entry_id == uuid:
+                            if integration_entities := er.async_entries_for_config_entry(
+                                entity_reg, entry.entry_id
+                            ):
+                                for entity in integration_entities:
+                                    if entity.domain == "sensor":
+                                        return entity.entity_id
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.error("Error getting View Assist sensor entity id: %s", err)
                 continue
-    return ""
+    return None

--- a/custom_components/vaca/custom.py
+++ b/custom_components/vaca/custom.py
@@ -34,6 +34,7 @@ class CustomActions(StrEnum):
     MEDIA_STOP = "stop"
     MEDIA_SET_VOLUME = "set-volume"
     REFRESH = "refresh"
+    RESTART_UI = "restart-ui"
     SCREEN_SLEEP = "screen-sleep"
     SCREEN_WAKE = "screen-wake"
     TOAST_MESSAGE = "toast-message"

--- a/custom_components/vaca/custom.py
+++ b/custom_components/vaca/custom.py
@@ -154,7 +154,7 @@ def getVADashboardPath(hass: HomeAssistant, uuid: str) -> str:
         )
         for entry in entries:
             try:
-                if entry.data["type"] == "vaca":
+                if entry.data["type"] in ("vaca", "view_audio"):
                     if mic_device := entry.data.get("mic_device", {}):
                         if mic_device_entity := entity_reg.async_get(mic_device):
                             entry_id = mic_device_entity.config_entry_id
@@ -180,7 +180,7 @@ def getVASensorEntityId(hass: HomeAssistant, uuid: str) -> str | None:
         entity_reg = er.async_get(hass)
         for entry in entries:
             try:
-                if entry.data["type"] != "vaca":
+                if entry.data["type"] not in ("vaca", "view_audio"):
                     continue
                 if mic_device := entry.data.get("mic_device", {}):
                     if mic_device_entity := entity_reg.async_get(mic_device):

--- a/custom_components/vaca/strings.json
+++ b/custom_components/vaca/strings.json
@@ -80,7 +80,7 @@
     },
     "text": {
       "screensaver_dashboard": {
-        "name": "Screensaver dashboard path"
+        "name": "Screensaver dashboard path (optional)"
       }
     }
   }

--- a/custom_components/vaca/strings.json
+++ b/custom_components/vaca/strings.json
@@ -28,6 +28,9 @@
     "binary_sensor": {
       "assist_in_progress": {
         "name": "[%key:component::assist_pipeline::entity::binary_sensor::assist_in_progress::name%]"
+      },
+      "ui_idle": {
+        "name": "UI idle"
       }
     },
     "select": {
@@ -73,6 +76,11 @@
       },
       "raw_proximity_threshold": {
         "name": "Raw proximity threshold"
+      }
+    },
+    "text": {
+      "screensaver_dashboard": {
+        "name": "Screensaver dashboard path"
       }
     }
   }

--- a/custom_components/vaca/switch.py
+++ b/custom_components/vaca/switch.py
@@ -260,7 +260,7 @@ class WyomingSatelliteContinueConversationSwitch(BaseSwitch):
         icon="mdi:message-bulleted",
         entity_category=EntityCategory.CONFIG,
     )
-    default_on = True
+    default_on = False
 
 
 class WyomingSatelliteAlarmSwitch(BaseFeedbackSwitch):

--- a/custom_components/vaca/text.py
+++ b/custom_components/vaca/text.py
@@ -1,0 +1,71 @@
+"""Text entities for VACA integration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.text import TextEntity, TextEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import restore_state
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN
+from .devices import VASatelliteDevice
+from .entity import VASatelliteEntity
+
+if TYPE_CHECKING:
+    from homeassistant.components.wyoming import DomainDataItem
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up text entities."""
+    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+    device: VASatelliteDevice = item.device  # type: ignore[assignment]
+
+    # Setup is only forwarded for satellites
+    assert device is not None
+
+    async_add_entities([WyomingSatelliteScreensaverDashboardText(device)])
+
+
+class WyomingSatelliteScreensaverDashboardText(
+    VASatelliteEntity, TextEntity, restore_state.RestoreEntity
+):
+    """Entity to configure screensaver dashboard path."""
+
+    entity_description = TextEntityDescription(
+        key="screensaver_dashboard",
+        translation_key="screensaver_dashboard",
+        entity_category=EntityCategory.CONFIG,
+    )
+
+    _attr_native_min = 0
+    _attr_native_max = 128
+    _attr_mode = "text"
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity about to be added to hass."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None:
+            await self.async_set_value(state.state or "")
+            return
+
+        await self.async_set_value("/dashboard-screensaver")
+
+    async def async_set_value(self, value: str) -> None:
+        """Update the value."""
+        clean = value.strip()
+        if clean and not clean.startswith("/"):
+            clean = f"/{clean}"
+
+        self._attr_native_value = clean
+        self.async_write_ha_state()
+        self._device.set_custom_setting(self.entity_description.key, clean)

--- a/custom_components/vaca/translations/de.json
+++ b/custom_components/vaca/translations/de.json
@@ -40,6 +40,9 @@
             "refresh": {
                 "name": "Aktualisieren"
             },
+            "restart_ui": {
+                "name": "UI neu starten"
+            },
             "screen_wake": {
                 "name": "Bildschirm aufwecken"
             },

--- a/custom_components/vaca/translations/en.json
+++ b/custom_components/vaca/translations/en.json
@@ -249,7 +249,7 @@
         },
         "text": {
             "screensaver_dashboard": {
-                "name": "Screensaver dashboard path"
+                "name": "Screensaver dashboard path (optional)"
             }
         }
     }

--- a/custom_components/vaca/translations/en.json
+++ b/custom_components/vaca/translations/en.json
@@ -32,6 +32,9 @@
             "screen_on": {
                 "name": "Screen"
             },
+            "ui_idle": {
+                "name": "UI idle"
+            },
             "motion_detected": {
                 "name": "Motion"
             }
@@ -242,6 +245,11 @@
             },
             "screen_saver": {
                 "name": "Screen saver"
+            }
+        },
+        "text": {
+            "screensaver_dashboard": {
+                "name": "Screensaver dashboard path"
             }
         }
     }

--- a/custom_components/vaca/translations/en.json
+++ b/custom_components/vaca/translations/en.json
@@ -43,6 +43,9 @@
             "refresh": {
                 "name": "Refresh"
             },
+            "restart_ui": {
+                "name": "Restart UI"
+            },
             "screen_wake": {
                 "name": "Wake screen"
             },

--- a/custom_components/vaca/translations/tr.json
+++ b/custom_components/vaca/translations/tr.json
@@ -37,6 +37,9 @@
             "refresh": {
                 "name": "Yenile"
             },
+            "restart_ui": {
+                "name": "Arayuzu yeniden baslat"
+            },
             "screen_wake": {
                 "name": "Ekranı uyandır"
             },


### PR DESCRIPTION
## Summary

This PR updates the VACA Home Assistant integration to coordinate correctly with the companion app screensaver/navigation changes.

It adds the integration-side handling needed for idle-driven dashboard screensaver behavior, preserves the original local screen-off fallback when no screensaver dashboard path is configured, and keeps settings propagation aligned with the app.

## Included changes

- Add integration-side handling for `ui_idle`-driven screensaver navigation
- Only trigger dashboard screensaver when the current path is the default home path
- Preserve local screen-off fallback when no screensaver dashboard path is configured
- Reset stale idle state on reconnect
- Allow blank screensaver dashboard path values
- Update screensaver-related settings propagation so partial updates do not disable the wrong behavior

## Validation

Validated with the companion app on the Lenovo tablet:

- idle transitions trigger dashboard screensaver when configured
- blank screensaver dashboard path restores original local screen-off behavior
- reconnects do not leave stale idle state behind
- settings updates continue to behave correctly with the app-side flow

## Related changes

This PR is one part of a coordinated update across the companion app and Home Assistant integrations.

Related PRs:
- App: msp1974/ViewAssistCompanionApp#27
- view_assist integration: msp1974/view_assist_integration#4

Recommended rollout: merge and deploy the related PRs together.
