### PR TITLE
fix: restore binary sensor off state

### DIFF
--- a/custom_components/vaca/binary_sensor.py
+++ b/custom_components/vaca/binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -70,7 +71,7 @@ class _WyomingSatelliteDeviceBinarySensorBase(
             state = await self.async_get_last_state()
             if state is not None:
                 # Restore the state of the binary sensor
-                self._attr_is_on = bool(state.state)
+                self._attr_is_on = state.state == STATE_ON
                 self.async_write_ha_state()
 
         self.async_on_remove(


### PR DESCRIPTION
The VACA screen binary sensor could restore incorrectly after Home Assistant restarted or the integration was reloaded.

The restore logic used `bool(state.state)`, but Home Assistant states are strings. In Python, both `"on"` and `"off"` are truthy, so a previously restored `"off"` state could incorrectly become `on`.

That made the screen binary sensor appear stuck on until a fresh status update arrived.

## What changed

- Imported `STATE_ON` from `homeassistant.const`.
- Changed binary sensor restore logic to compare the restored state explicitly against `STATE_ON`.

Before:

```python
self._attr_is_on = bool(state.state)
```

After:

```python
self._attr_is_on = state.state == STATE_ON
```

## Behavioral impact

- Binary sensors now restore `off` as `off`.
- Screen binary sensor state after restart or reload is no longer biased toward `on`.
- Runtime status update behavior is unchanged.

## Validation

- Compiled `custom_components/vaca/binary_sensor.py` with `py_compile`.
- Applied the same change on a live Home Assistant instance and confirmed the file loads syntactically.

See also changes here: https://github.com/msp1974/ViewAssistCompanionApp/pull/35