### PR TITLE
Implement RestoreEntity for Volume Level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ env.bak/
 venv.bak/
 
 .vscode
+custom_components/.DS_Store

--- a/custom_components/vaca/media_player.py
+++ b/custom_components/vaca/media_player.py
@@ -20,6 +20,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .custom import CustomActions
@@ -47,7 +48,7 @@ async def async_setup_entry(
     async_add_entities([WyomingMediaPlayer(device)])
 
 
-class WyomingMediaPlayer(VASatelliteEntity, MediaPlayerEntity):
+class WyomingMediaPlayer(VASatelliteEntity, MediaPlayerEntity, RestoreEntity):
     """Represents a hassmic media player."""
 
     _listener_class = "status_update"
@@ -77,6 +78,10 @@ class WyomingMediaPlayer(VASatelliteEntity, MediaPlayerEntity):
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
         await super().async_added_to_hass()
+
+        if last_state := await self.async_get_last_state():
+            if "volume_level" in last_state.attributes:
+                self._attr_volume_level = last_state.attributes["volume_level"]
 
         self.async_on_remove(
             async_dispatcher_connect(


### PR DESCRIPTION
When home assistant restarts the volume level defaults to 90% regardless of the volume prior to the restart. With this PR, it will now restore to its previous level prior to the restart. 

### Tests Performed
- Updated integration (which went to 90%) and set the media player volume to 15%.
- Restarted Home Assistant.
- Verified that the media player restored its volume to 15% instead of reverting to 90%.