### PR TITLE
Bound the TCP connect in load_wyoming_info with the info timeout

### DIFF
--- a/custom_components/vaca/data.py
+++ b/custom_components/vaca/data.py
@@ -116,7 +116,7 @@ async def load_wyoming_info(
 
     for _ in range(retries + 1):
         try:
-            async with AsyncTcpClient(host, port) as client, asyncio.timeout(timeout):
+            async with asyncio.timeout(timeout), AsyncTcpClient(host, port) as client:
                 # Describe -> Info
                 await client.write_event(Describe().event())
                 while True:


### PR DESCRIPTION
Fixes #271.

`async with A, B` enters its context managers left to right, so in `load_wyoming_info()` the `asyncio.timeout(timeout)` was only armed **after** `AsyncTcpClient.__aenter__()` had already completed the TCP connect. `_INFO_TIMEOUT` covered the Describe/Info and Capabilities exchange but not the connect itself.

Against a host that refuses connections this is invisible — `ConnectionRefusedError` lands in `except OSError` and the retry works. Against a host that silently drops SYNs (an Android satellite that keeps its Wi-Fi association but stops answering), `asyncio.open_connection()` awaits forever inside the retry loop, so `except TimeoutError` never runs, `create()` never returns `None`, `async_setup_entry` never raises `ConfigEntryNotReady`, and the config entry sits in `setup_in_progress` — "Initializing" in the UI — until Home Assistant restarts, which just re-enters the same unbounded connect.

Swapping the two context managers arms the timeout first, so the connect is bounded by `_INFO_TIMEOUT` like the rest of the handshake. Everything downstream already does the right thing: the existing retry runs, `ConfigEntryNotReady` is raised, and Home Assistant's normal retry schedule reconnects the satellite by itself once the device returns.

One line, no behaviour change on a healthy or actively-refusing device.
