### PR TITLE
Add option to prefer external HA URL for satellite devices

### DIFF
--- a/custom_components/vaca/assist_satellite.py
+++ b/custom_components/vaca/assist_satellite.py
@@ -153,9 +153,21 @@ class ViewAssistSatelliteEntity(WyomingAssistSatellite, VASatelliteEntity):
                 self.device.custom_settings["ha_port"] = (
                     self.hass.config.api.port if self.hass.config.api else 8123
                 )
-                self.device.custom_settings["ha_url"] = (
-                    self.hass.config.internal_url or ""
+                prefer_external = bool(
+                    self.device.custom_settings.get("prefer_external_url", False)
                 )
+                if prefer_external:
+                    self.device.custom_settings["ha_url"] = (
+                        self.hass.config.external_url
+                        or self.hass.config.internal_url
+                        or ""
+                    )
+                else:
+                    self.device.custom_settings["ha_url"] = (
+                        self.hass.config.internal_url
+                        or self.hass.config.external_url
+                        or ""
+                    )
                 home = getVADashboardPath(self.hass, self.device.satellite_id)
                 self.device.custom_settings["ha_dashboard"] = home.removeprefix("/")
 

--- a/custom_components/vaca/strings.json
+++ b/custom_components/vaca/strings.json
@@ -59,6 +59,9 @@
     "switch": {
       "mute": {
         "name": "Mute"
+      },
+      "prefer_external_url": {
+        "name": "Prefer external URL"
       }
     },
     "number": {

--- a/custom_components/vaca/switch.py
+++ b/custom_components/vaca/switch.py
@@ -46,6 +46,7 @@ async def async_setup_entry(
         WyomingSatelliteAlarmSwitch(device),
         WyomingSatelliteScreenOnWakeWordSwitch(device),
         WyomingSatelliteScreenSaverSwitch(device),
+        WyomingSatellitePreferExternalUrlSwitch(device),
     ]
 
     if capabilities := device.capabilities:
@@ -321,5 +322,22 @@ class WyomingSatelliteScreenSaverSwitch(BaseFeedbackSwitch):
         key="screen_saver",
         translation_key="screen_saver",
         icon="mdi:monitor-shimmer",
+    )
+    default_on = False
+
+
+class WyomingSatellitePreferExternalUrlSwitch(BaseSwitch):
+    """Entity to control whether the satellite is given the external HA URL.
+
+    Enable this only when the satellite reaches Home Assistant through
+    Tailscale, another VPN, or a remote/DDNS address rather than the local
+    network, since the internal URL will not be reachable from it.
+    """
+
+    entity_description = SwitchEntityDescription(
+        key="prefer_external_url",
+        translation_key="prefer_external_url",
+        icon="mdi:vpn",
+        entity_category=EntityCategory.CONFIG,
     )
     default_on = False

--- a/custom_components/vaca/translations/en.json
+++ b/custom_components/vaca/translations/en.json
@@ -255,6 +255,9 @@
             },
             "screen_saver": {
                 "name": "Screen saver"
+            },
+            "prefer_external_url": {
+                "name": "Prefer external URL"
             }
         }
     }


### PR DESCRIPTION
## Summary

Satellite devices are given a Home Assistant URL (`ha_url`) on every reconnect, which the companion app uses for dashboard/API calls (separate from the Wyoming socket used to pair/stream audio). Previously this always used `internal_url`.

That default breaks down for satellites that reach Home Assistant over Tailscale, another VPN, or a remote/DDNS address instead of the local network: `internal_url` is typically a LAN-only address (e.g. a private IP or `.local` hostname) that such a device cannot route to, even though the Wyoming connection itself works fine over the tunnel. In that setup the app silently fails to load its dashboard because it was handed an address it can never reach.

A single fixed preference (always internal, or always external) can't be correct for every topology — a wall-mounted satellite on the same LAN as Home Assistant should stay local (avoiding a routing hop and any dependency on internet/VPN uptime), while a remote/VPN-connected satellite needs the external address. Since there's no reliable way to detect which situation applies at the point `ha_url` is computed (it isn't tied to an inbound HTTP request, so there's no source IP to inspect), this is exposed as an explicit per-device toggle rather than guessed automatically.

## Changes

- Added a new `Prefer external URL` config switch per satellite device (`custom_components/vaca/switch.py`), off by default.
- When enabled, `ha_url` is resolved as `external_url` → `internal_url` → `""`; when disabled (default), it stays `internal_url` → `external_url` → `""` (`custom_components/vaca/assist_satellite.py`).
- Added translation strings for the new switch.

## Test plan

- [ ] Verify the new "Prefer external URL" switch appears under the satellite device's configuration entities.
- [ ] With the switch off (default), confirm `ha_url` sent to the device matches `internal_url` when both internal and external URLs are configured.
- [ ] With the switch on, confirm `ha_url` sent to the device matches `external_url`.
- [ ] Confirm the switch state persists across Home Assistant restarts.