### PR TITLE
fix: restore motion detection mode on startup

### DIFF
--- a/custom_components/vaca/select.py
+++ b/custom_components/vaca/select.py
@@ -153,7 +153,7 @@ class WyomingSatelliteMotionDetectionModeSelect(
 
         state = await self.async_get_last_state()
         if state is not None and state.state in self.options:
-            self._attr_current_option = state.state
+            await self.async_select_option(state.state)
 
     async def async_select_option(self, option: str) -> None:
         """Select an option."""


### PR DESCRIPTION
This fixes VACA forgetting the motion detection mode after a restart. Home Assistant still showed motion, but the setting wasnt actually sent to VACA, so the camera stayed off. Tested on an Echo Show 5 and the camera now starts correctly without reselecting the option.

Fixes https://github.com/msp1974/ViewAssist_Companion_App/issues/262