### PR TITLE
Add RTSP stream rotation, mirror, and full stream control entities

### DIFF
--- a/custom_components/vaca/number.py
+++ b/custom_components/vaca/number.py
@@ -53,6 +53,10 @@ async def async_setup_entry(
 
     if device.capabilities and device.capabilities.get("has_front_camera"):
         entities.append(WyomingSatelliteMotionDetectionSensitivityNumber(device))
+        entities.append(WyomingSatelliteRTSPStreamPortNumber(device))
+        entities.append(WyomingSatelliteRTSPStreamWidthNumber(device))
+        entities.append(WyomingSatelliteRTSPStreamHeightNumber(device))
+        entities.append(WyomingSatelliteRTSPStreamFpsNumber(device))
     if (
         device.capabilities
         and device.capabilities.get("proximity_sensor_type") == "raw"
@@ -458,6 +462,138 @@ class WyomingSatelliteBumpDetectionSensitivityNumber(VASatelliteEntity, RestoreN
         self.async_write_ha_state()
         # Sensitivity is sent as 1-10 scale
         self._device.set_custom_setting(self.entity_description.key, 11 - value)
+
+
+class WyomingSatelliteRTSPStreamPortNumber(VASatelliteEntity, RestoreNumber):
+    """Entity to represent the RTSP camera stream port."""
+
+    entity_description = NumberEntityDescription(
+        key="rtsp_stream_port",
+        translation_key="rtsp_stream_port",
+        icon="mdi:lan-connect",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = 1024
+    _attr_native_max_value = 65535
+    _attr_native_step = 1
+    _attr_native_value = 8554
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None:
+            await self.async_set_native_value(float(state.state))
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        value = int(
+            max(self._attr_native_min_value, min(self._attr_native_max_value, value))
+        )
+        self._attr_native_value = value
+        self.async_write_ha_state()
+        self._device.set_custom_setting(self.entity_description.key, value)
+
+
+class WyomingSatelliteRTSPStreamWidthNumber(VASatelliteEntity, RestoreNumber):
+    """Entity to represent the RTSP camera stream width."""
+
+    entity_description = NumberEntityDescription(
+        key="rtsp_stream_width",
+        translation_key="rtsp_stream_width",
+        icon="mdi:arrow-expand-horizontal",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = 160
+    _attr_native_max_value = 1920
+    _attr_native_step = 1
+    _attr_native_value = 640
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None:
+            await self.async_set_native_value(float(state.state))
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        value = int(
+            max(self._attr_native_min_value, min(self._attr_native_max_value, value))
+        )
+        self._attr_native_value = value
+        self.async_write_ha_state()
+        self._device.set_custom_setting(self.entity_description.key, value)
+
+
+class WyomingSatelliteRTSPStreamHeightNumber(VASatelliteEntity, RestoreNumber):
+    """Entity to represent the RTSP camera stream height."""
+
+    entity_description = NumberEntityDescription(
+        key="rtsp_stream_height",
+        translation_key="rtsp_stream_height",
+        icon="mdi:arrow-expand-vertical",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = 120
+    _attr_native_max_value = 1080
+    _attr_native_step = 1
+    _attr_native_value = 480
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None:
+            await self.async_set_native_value(float(state.state))
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        value = int(
+            max(self._attr_native_min_value, min(self._attr_native_max_value, value))
+        )
+        self._attr_native_value = value
+        self.async_write_ha_state()
+        self._device.set_custom_setting(self.entity_description.key, value)
+
+
+class WyomingSatelliteRTSPStreamFpsNumber(VASatelliteEntity, RestoreNumber):
+    """Entity to represent the RTSP camera stream frame rate."""
+
+    entity_description = NumberEntityDescription(
+        key="rtsp_stream_fps",
+        translation_key="rtsp_stream_fps",
+        icon="mdi:filmstrip",
+        entity_category=EntityCategory.CONFIG,
+    )
+    _attr_should_poll = False
+    _attr_native_min_value = 1
+    _attr_native_max_value = 30
+    _attr_native_step = 1
+    _attr_native_value = 15
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None:
+            await self.async_set_native_value(float(state.state))
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        value = int(
+            max(self._attr_native_min_value, min(self._attr_native_max_value, value))
+        )
+        self._attr_native_value = value
+        self.async_write_ha_state()
+        self._device.set_custom_setting(self.entity_description.key, value)
 
 
 class WyomingSatelliteRawProximityThresholdNumber(VASatelliteEntity, RestoreNumber):

--- a/custom_components/vaca/number.py
+++ b/custom_components/vaca/number.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Final, Any
 
 from homeassistant.components.number import NumberEntityDescription, RestoreNumber
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -75,7 +75,7 @@ class BaseNumberEntity(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -289,7 +289,7 @@ class WyomingSatelliteScreenBrightnessNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -320,7 +320,7 @@ class WyomingSatelliteWakeWordThresholdNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -352,7 +352,7 @@ class WyomingSatelliteZoomLevelNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -385,7 +385,7 @@ class WyomingSatelliteTextSizeNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -420,7 +420,7 @@ class WyomingSatelliteMotionDetectionSensitivityNumber(
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -452,7 +452,7 @@ class WyomingSatelliteBumpDetectionSensitivityNumber(VASatelliteEntity, RestoreN
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -484,7 +484,7 @@ class WyomingSatelliteRTSPStreamPortNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -517,7 +517,7 @@ class WyomingSatelliteRTSPStreamWidthNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -550,7 +550,7 @@ class WyomingSatelliteRTSPStreamHeightNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -583,7 +583,7 @@ class WyomingSatelliteRTSPStreamFpsNumber(VASatelliteEntity, RestoreNumber):
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:
@@ -615,7 +615,7 @@ class WyomingSatelliteRawProximityThresholdNumber(VASatelliteEntity, RestoreNumb
         await super().async_added_to_hass()
 
         state = await self.async_get_last_state()
-        if state is not None:
+        if state is not None and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             await self.async_set_native_value(float(state.state))
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/vaca/select.py
+++ b/custom_components/vaca/select.py
@@ -66,6 +66,7 @@ async def async_setup_entry(
 
     if device.capabilities and device.capabilities.get("has_front_camera"):
         entities.append(WyomingSatelliteMotionDetectionModeSelect(device))
+        entities.append(WyomingSatelliteRTSPStreamRotationSelect(device))
 
     if entities:
         async_add_entities(entities)
@@ -456,3 +457,33 @@ class WyomingSatelliteScreenOrientationModeSelect(
         self._attr_current_option = option
         self.async_write_ha_state()
         self._device.set_custom_setting("screen_orientation_mode", option)
+
+
+class WyomingSatelliteRTSPStreamRotationSelect(
+    VASatelliteEntity, SelectEntity, restore_state.RestoreEntity
+):
+    """Entity to represent RTSP camera stream rotation setting."""
+
+    entity_description = SelectEntityDescription(
+        key="rtsp_stream_rotation",
+        translation_key="rtsp_stream_rotation",
+        entity_category=EntityCategory.CONFIG,
+        icon="mdi:rotate-right",
+    )
+    _attr_should_poll = False
+    _attr_current_option = "0"
+    _attr_options = ["0", "90", "180", "270"]
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        state = await self.async_get_last_state()
+        if state is not None and state.state in self.options:
+            await self.async_select_option(state.state)
+
+    async def async_select_option(self, option: str) -> None:
+        """Select an option."""
+        self._attr_current_option = option
+        self.async_write_ha_state()
+        self._device.set_custom_setting(self.entity_description.key, int(option))

--- a/custom_components/vaca/switch.py
+++ b/custom_components/vaca/switch.py
@@ -60,6 +60,8 @@ async def async_setup_entry(
 
     if device.capabilities and device.capabilities.get("has_front_camera"):
         entities.append(WyomingSatelliteScreenOnMotionSwitch(device))
+        entities.append(WyomingSatelliteRTSPStreamEnabledSwitch(device))
+        entities.append(WyomingSatelliteRTSPStreamMirrorSwitch(device))
 
     if entities:
         async_add_entities(entities)
@@ -364,5 +366,29 @@ class WyomingSatelliteScreenSaverSwitch(BaseFeedbackSwitch):
         key="screen_saver",
         translation_key="screen_saver",
         icon="mdi:monitor-shimmer",
+    )
+    default_on = False
+
+
+class WyomingSatelliteRTSPStreamEnabledSwitch(BaseSwitch):
+    """Entity to control the RTSP camera stream on/off."""
+
+    entity_description = SwitchEntityDescription(
+        key="rtsp_stream_enabled",
+        translation_key="rtsp_stream_enabled",
+        icon="mdi:cctv",
+        entity_category=EntityCategory.CONFIG,
+    )
+    default_on = False
+
+
+class WyomingSatelliteRTSPStreamMirrorSwitch(BaseSwitch):
+    """Entity to control horizontal mirroring of the RTSP camera stream."""
+
+    entity_description = SwitchEntityDescription(
+        key="rtsp_stream_mirror",
+        translation_key="rtsp_stream_mirror",
+        icon="mdi:flip-horizontal",
+        entity_category=EntityCategory.CONFIG,
     )
     default_on = False

--- a/custom_components/vaca/translations/en.json
+++ b/custom_components/vaca/translations/en.json
@@ -113,6 +113,18 @@
             },
             "bump_sensitivity": {
                 "name": "Bump sensitivity"
+            },
+            "rtsp_stream_port": {
+                "name": "RTSP stream port"
+            },
+            "rtsp_stream_width": {
+                "name": "RTSP stream width"
+            },
+            "rtsp_stream_height": {
+                "name": "RTSP stream height"
+            },
+            "rtsp_stream_fps": {
+                "name": "RTSP stream FPS"
             }
         },
         "select": {
@@ -185,6 +197,15 @@
                     "none": "Off",
                     "motion": "Motion",
                     "face": "Face"
+                }
+            },
+            "rtsp_stream_rotation": {
+                "name": "RTSP stream rotation",
+                "state": {
+                    "0": "0°",
+                    "90": "90°",
+                    "180": "180°",
+                    "270": "270°"
                 }
             }
         },
@@ -270,6 +291,12 @@
             },
             "screen_saver": {
                 "name": "Screen saver"
+            },
+            "rtsp_stream_enabled": {
+                "name": "RTSP stream"
+            },
+            "rtsp_stream_mirror": {
+                "name": "RTSP stream mirror"
             }
         }
     }


### PR DESCRIPTION
adds functions added via PR 54 to the app in the other repo
addresses issues #62 

adds RTSP streaming from the app, with the following controls:

- turn on/off RTSP streaming
- adjust FPS
- adjust RTSP port
- adjust rtsp stream width and height
- mirror rtsp stream
- rotate rtsp stream 90, 180, 270 clockwise

Note, turning RTSP streaming on will disable motion detection as only one function can grab the camera, figured its an OK compromise as if you are streaming RTPS you can use other tools like frigate to detect motion.

Binds only to default front facing camera, didnt think there was a common use case for a back camera, or multiple front facing cameras., so no camera selector implemented

limited testing done with a thinksmart view and an galaxy s9

this was co-authered with claude code